### PR TITLE
Fix spelling in Analytics service tags

### DIFF
--- a/src/components/Services/Services.tsx
+++ b/src/components/Services/Services.tsx
@@ -106,7 +106,7 @@ const SERVICES = [
       "Attribution Modeling",
       "Customer Segmentation",
       "A/B Test Design",
-      "Mutivariate Test Design",
+      "Multivariate Test Design",
       "Data Visualization",
     ],
   },


### PR DESCRIPTION
## Summary
- Correct typo in Analytics service tags: change "Mutivariate Test Design" to "Multivariate Test Design"

------
https://chatgpt.com/codex/tasks/task_e_689980d4e73883208766a72797cc8f94