### PR TITLE
Handle missing window in useScrollPosition

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
-    "test": "next build"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",
@@ -36,7 +36,8 @@
     "@types/react": "npm:types-react@19.0.0-rc.1",
     "@types/styled-components": "^5.1.7",
     "firebase-tools": "^9.2.2",
-    "typescript": "^5.4.3"
+    "typescript": "^5.4.3",
+    "vitest": "^1.6.0"
   },
   "prettier": {},
   "overrides": {

--- a/src/hooks/__tests__/useScrollPosition.test.tsx
+++ b/src/hooks/__tests__/useScrollPosition.test.tsx
@@ -1,0 +1,17 @@
+import React, { useRef } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+
+import useScrollPosition from "../useScrollPosition";
+
+function TestComponent() {
+  const ref = useRef<HTMLElement>(null!);
+  useScrollPosition(ref);
+  return null;
+}
+
+describe("useScrollPosition", () => {
+  it("does not throw when window is undefined", () => {
+    expect(() => renderToString(<TestComponent />)).not.toThrow();
+  });
+});

--- a/src/hooks/useScrollPosition.tsx
+++ b/src/hooks/useScrollPosition.tsx
@@ -18,18 +18,19 @@ const useScrollPosition = (
   const onScroll = throttle(handleScroll, 200);
   const scroll = useCallback(onScroll, [el]);
   const onDestroy = () => {
-    wdw.current.removeEventListener("scroll", scroll);
+    if (wdw.current) wdw.current.removeEventListener("scroll", scroll);
   };
   const destroy = useCallback(onDestroy, [el]);
 
   useEffect(() => {
+    if (!wdw.current) return;
     wdw.current.addEventListener("scroll", scroll);
 
     return destroy;
   }, [el]);
 
   useEffect(() => {
-    setDistanceFromTop(wdw.current.scrollY);
+    if (wdw.current) setDistanceFromTop(wdw.current.scrollY);
   }, []);
 
   if (typeof window === "undefined" || !el.current) return [];


### PR DESCRIPTION
## Summary
- guard calls to `window` APIs within `useScrollPosition`
- add a unit test ensuring the hook does not error when `window` is undefined
- use vitest for running tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689980db2e64832090544729a7c5cc46