### PR TITLE
fix: handle optional subject in contact message

### DIFF
--- a/src/components/Contact/createMessage.ts
+++ b/src/components/Contact/createMessage.ts
@@ -35,8 +35,12 @@ const createMessage = async ({
 }: INewMessageRaw) => {
   const sanitizedMessage: INewMessage = {
     from,
-    message: { text, subject: `[ITOLEAD] ${from} – ${subject}` },
+    message: { text },
   };
+
+  if (subject) {
+    sanitizedMessage.message.subject = `[ITOLEAD] ${from} – ${subject}`;
+  }
 
   return onCreateMessage(sanitizedMessage);
 };


### PR DESCRIPTION
## Summary
- avoid sending literal 'undefined' in message subject when no subject provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68998003f580832091843ced8d70c045