### PR TITLE
fix: hide greeting text before animation

### DIFF
--- a/src/components/Greeting/Greeting.tsx
+++ b/src/components/Greeting/Greeting.tsx
@@ -36,7 +36,7 @@ const Greeting = () => {
 
           <p className="greeting greeting--name greeting--typing">
             <TypingDots />
-            <span className="greeting-text">
+            <span className="greeting-text" style={{ opacity: 0 }}>
               I love building things with code
             </span>
           </p>


### PR DESCRIPTION
## Summary
- hide greeting text until bubble animation completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68998e2ae5d4832085dee75324c9eaa9