### PR TITLE
fix: sync greeting text with bubble animation

### DIFF
--- a/src/components/Greeting/Greeting.animation.tsx
+++ b/src/components/Greeting/Greeting.animation.tsx
@@ -21,6 +21,11 @@ export function useAnimation(ref: any) {
         easing: "easeOutExpo",
       })
       .add({
+        targets: ".greeting--name .greeting-text",
+        opacity: 0,
+        duration: 0,
+      })
+      .add({
         targets: ".greeting--name",
         translateY: ["-100%", "0%"],
         opacity: 1,
@@ -33,13 +38,14 @@ export function useAnimation(ref: any) {
             duration: 600,
             delay: anime.stagger(80),
             easing: "easeInOutCubic",
-            loop: 2,
+            loop: 4,
           });
         },
       })
       .add({
         targets: ".greeting--name",
         opacity: 0,
+        delay: 2600,
         complete() {
           toggleTypingStatus(".greeting--name");
           document
@@ -53,21 +59,18 @@ export function useAnimation(ref: any) {
         opacity: 1,
         duration: 280,
       })
-      .add(
-        {
-          targets: ".greeting--name .greeting-text",
-          opacity: 1,
-          complete() {
-            anime({
-              easing: "easeOutExpo",
-              targets: [".lead", ".featured", ".featured-item"],
-              translateY: ["100%", "0%"],
-              opacity: 1,
-            });
-          },
+      .add({
+        targets: ".greeting--name .greeting-text",
+        opacity: 1,
+        complete() {
+          anime({
+            easing: "easeOutExpo",
+            targets: [".lead", ".featured", ".featured-item"],
+            translateY: ["100%", "0%"],
+            opacity: 1,
+          });
         },
-        "-=1200"
-      )
+      })
       .add(
         {
           targets: ".bt-1",

--- a/src/components/Greeting/Greeting.tsx
+++ b/src/components/Greeting/Greeting.tsx
@@ -36,7 +36,7 @@ const Greeting = () => {
 
           <p className="greeting greeting--name greeting--typing">
             <TypingDots />
-            <span className="greeting-text">
+            <span className="greeting-text" style={{ opacity: 0 }}>
               I love building things with code
             </span>
           </p>


### PR DESCRIPTION
## Summary
- fade greeting text to opacity 0 instantly to avoid flashing before the bubble appears
- extend typing dot animation and delay bubble fade-out for a longer loading effect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998e2ae5d4832085dee75324c9eaa9